### PR TITLE
Revert "Switch the plugin to use Cowboy REST"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_shovel_management
 
-DEPS = rabbit_common rabbit rabbitmq_management rabbitmq_shovel
+DEPS = rabbit_common rabbit rabbitmq_management rabbitmq_shovel webmachine
 TEST_DEPS = rabbitmq_ct_helpers
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/src/rabbit_shovel_mgmt.erl
+++ b/src/rabbit_shovel_mgmt.erl
@@ -19,28 +19,25 @@
 -behaviour(rabbit_mgmt_extension).
 
 -export([dispatcher/0, web_ui/0]).
--export([init/3, rest_init/2, to_json/2, resource_exists/2, content_types_provided/2,
+-export([init/1, to_json/2, resource_exists/2, content_types_provided/2,
          is_authorized/2]).
 
 -import(rabbit_misc, [pget/2]).
 
 -include_lib("rabbitmq_management/include/rabbit_mgmt.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
 
-dispatcher() -> [{"/shovels",        ?MODULE, []},
-                 {"/shovels/:vhost", ?MODULE, []}].
+dispatcher() -> [{["shovels"],        ?MODULE, []},
+                 {["shovels", vhost], ?MODULE, []}].
 web_ui()     -> [{javascript, <<"shovel.js">>}].
 
 %%--------------------------------------------------------------------
 
-init(_, _, _) ->
-    {upgrade, protocol, cowboy_rest}.
-
-rest_init(Req, _Opts) ->
-    {ok, Req, #context{}}.
+init(_Config) -> {ok, #context{}}.
 
 content_types_provided(ReqData, Context) ->
-   {[{<<"application/json">>, to_json}], ReqData, Context}.
+   {[{"application/json", to_json}], ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
     {case rabbit_mgmt_util:vhost(ReqData) of

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -97,22 +97,22 @@ start_inets(Config) ->
 
 shovels(Config) ->
     http_put(Config, "/users/admin",
-      [{password, <<"admin">>}, {tags, <<"administrator">>}], ?CREATED),
+      [{password, <<"admin">>}, {tags, <<"administrator">>}], ?NO_CONTENT),
     http_put(Config, "/users/mon",
-      [{password, <<"mon">>}, {tags, <<"monitoring">>}], ?CREATED),
-    http_put(Config, "/vhosts/v", none, ?CREATED),
+      [{password, <<"mon">>}, {tags, <<"monitoring">>}], ?NO_CONTENT),
+    http_put(Config, "/vhosts/v", none, ?NO_CONTENT),
     Perms = [{configure, <<".*">>},
              {write,     <<".*">>},
              {read,      <<".*">>}],
-    http_put(Config, "/permissions/v/guest",  Perms, ?CREATED),
-    http_put(Config, "/permissions/v/admin",  Perms, ?CREATED),
-    http_put(Config, "/permissions/v/mon",    Perms, ?CREATED),
+    http_put(Config, "/permissions/v/guest",  Perms, ?NO_CONTENT),
+    http_put(Config, "/permissions/v/admin",  Perms, ?NO_CONTENT),
+    http_put(Config, "/permissions/v/mon",    Perms, ?NO_CONTENT),
 
     [http_put(Config, "/parameters/shovel/" ++ V ++ "/my-dynamic",
               [{value, [{'src-uri', <<"amqp://">>},
                         {'dest-uri', <<"amqp://">>},
                         {'src-queue', <<"test">>},
-                        {'dest-queue', <<"test2">>}]}], ?CREATED)
+                        {'dest-queue', <<"test2">>}]}], ?NO_CONTENT)
      || V <- ["%2f", "v"]],
     Static = [{name,  <<"my-static">>},
               {type,  <<"static">>}],


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-shovel-management#9, which was meant to ship with `rabbitmq-management-236`.