### PR TITLE
Use prefix for refresh link name

### DIFF
--- a/priv/www/js/shovel.js
+++ b/priv/www/js/shovel.js
@@ -84,7 +84,7 @@ dispatcher_add(function(sammy) {
                 go_to('#/dynamic-shovels');
             return false;
         });
-    sammy.del("#/restart-link", function(){
+    sammy.del("#/shovel-restart-link", function(){
         if(sync_delete(this, '/shovels/vhost/:vhost/:name/restart')){
             update();
         }

--- a/priv/www/js/tmpl/shovels.ejs
+++ b/priv/www/js/tmpl/shovels.ejs
@@ -59,7 +59,7 @@
 <% } %>
 <% if (shovel.type == 'dynamic') { %>
     <td>
-     <form action="#/restart-link" method="delete" class="confirm">
+     <form action="#/shovel-restart-link" method="delete" class="confirm">
      <input type="hidden" name="name" value="<%= shovel.name %>"/>
      <input type="hidden" name="vhost" value="<%= shovel.vhost %>"/>
      <input type="submit" value="Restart"/>


### PR DESCRIPTION
To avoid conflict with another link.

Fixes #35