### PR TITLE
Handle undefined URL in shovel status

### DIFF
--- a/priv/www/js/tmpl/shovels.ejs
+++ b/priv/www/js/tmpl/shovels.ejs
@@ -50,10 +50,10 @@
 <% } else { %>
     <td><%= fmt_state('green', shovel.state) %></td>
       <td><%= fmt_string(shovel.src_protocol) %></td>
-      <td><%= fmt_string(fmt_uri_with_credentials(shovel.src_uri)) %></td>
+      <td><%= shovel.src_uri == undefined ? fmt_string(shovel.src_uri) : fmt_string(fmt_uri_with_credentials(shovel.src_uri)) %></td>
       <td><%= fmt_shovel_endpoint('src_', shovel) %></td>
       <td><%= fmt_string(shovel.dest_protocol) %></td>
-      <td><%= fmt_string(fmt_uri_with_credentials(shovel.dest_uri)) %></td>
+      <td><%= shovel.dest_uri == undefined ? fmt_string(shovel.dest_uri) : fmt_string(fmt_uri_with_credentials(shovel.dest_uri)) %></td>
       <td><%= fmt_shovel_endpoint('dest_', shovel) %></td>
     <td><%= shovel.timestamp %></td>
 <% } %>


### PR DESCRIPTION
URLs can be undefined, e.g. after a refresh, this commit handles this
case to avoid displaying plain HTML in the cell.

Fixes #37